### PR TITLE
Bertabsolute : prendre les valeurs aboslues dans BERTopic TS

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -954,7 +954,7 @@ def write_bertopic_TS(topics, topics_info, group_type, party_day_counts, origin_
         ) as f:
             writer = csv.writer(f)
             if group_type == "congress":
-                writer.writerow(["date", "party", "topic", "prop"])
+                writer.writerow(["date", "party", "topic", "prop", "nb_tweets"])
             if group_type == "supporter" or group_type == "congress":
                 for doc_count, party, day in party_day_counts:
                     writer.writerow(
@@ -963,6 +963,7 @@ def write_bertopic_TS(topics, topics_info, group_type, party_day_counts, origin_
                             f"{party}_supp" if group_type == "supporter" else party,
                             topic,
                             round(topics_info[topic][party][day] / (doc_count), 5),
+                            topics_info[topic][party][day] 
                         ]
                     )
             else:
@@ -973,5 +974,6 @@ def write_bertopic_TS(topics, topics_info, group_type, party_day_counts, origin_
                             group_type,
                             topic,
                             round(topics_info[topic][day] / (doc_count), 5),
+                            topics_info[topic][party][day] 
                         ]
                     )

--- a/utils.py
+++ b/utils.py
@@ -974,6 +974,6 @@ def write_bertopic_TS(topics, topics_info, group_type, party_day_counts, origin_
                             group_type,
                             topic,
                             round(topics_info[topic][day] / (doc_count), 5),
-                            topics_info[topic][party][day] 
+                            topics_info[topic][day] 
                         ]
                     )


### PR DESCRIPTION
- Write_bertopic_TS conserve le nombre de tweets par jour par topic (mais la proportion est conservée pour le dashboard) 
- Je fais ça car je veux passer le VAR en valeur absolue (nombre de tweet au lieu de proportion d'attention pour des questions d'hypothèses statistiques) 
- Test effectué avec xan : Calculs relancés sur BERT. Puis j'ai pris un jour et un groupe au hasard, et j'ai bien que nb_tweet topic / tweet total du jour est égal à la proportion. 
